### PR TITLE
Add support of national variants (com, de, fr, co.uk)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Copyright
 ---------
 
   - Copyright 2015 Stephen Herbein <stephen272@gmail.com>
+  - Copyright 2015 Steffen Coenen <steffen@steffen-coenen.de>
   - Copyright 2014-2015 Jiří Janoušek <janousek.jiri@gmail.com>
   - Copyright 2012 Alexander King (src/icon.svg)
   - License: [2-Clause BSD-license](./LICENSE)

--- a/integrate.js
+++ b/integrate.js
@@ -1,5 +1,6 @@
 /*
  * Copyright 2015 Stephen Herbein <stephen272@gmail.com>
+ * Copyright 2015 Steffen Coenen <steffen@steffen-coenen.de>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met: 

--- a/integrate.js
+++ b/integrate.js
@@ -27,6 +27,19 @@
 (function(Nuvola)
 {
 
+// Translations
+var _ = Nuvola.Translate.gettext;
+var C_ = Nuvola.Translate.pgettext;
+
+var COUNTRY_VARIANT = "app.country_variant";
+var HOME_PAGE = "http://www.amazon.{1}/gp/dmusic/mp3/player";
+var COUNTRY_VARIANTS = [
+    ["de", C_("Amazon variant", "Germany")],
+    ["fr", C_("Amazon variant", "France")],
+    ["co.uk", C_("Amazon variant", "United Kingdom")],
+    ["com", C_("Amazon variant", "United States")]
+];
+
 // Create media player component
 var player = Nuvola.$object(Nuvola.MediaPlayer);
 
@@ -41,10 +54,11 @@ var WebApp = Nuvola.$WebApp();
 WebApp._onInitWebWorker = function(emitter)
 {
     Nuvola.WebApp._onInitWebWorker.call(this, emitter);
-
+    Nuvola.config.setDefault(COUNTRY_VARIANT, "");
     this.state = PlaybackState.UNKNOWN;
 
     document.addEventListener("DOMContentLoaded", this._onPageReady.bind(this));
+    Nuvola.core.connect("InitializationForm", this);
 }
 
 // Page is ready for magic
@@ -56,6 +70,39 @@ WebApp._onPageReady = function()
 
     // Start update routine
     this.update();
+}
+
+WebApp._onInitializationForm = function(emitter, values, entries)
+{
+    if (!Nuvola.config.hasKey(COUNTRY_VARIANT))
+        this.appendPreferences(values, entries);
+}
+
+WebApp.appendPreferences = function(values, entries)
+{
+    values[COUNTRY_VARIANT] = Nuvola.config.get(COUNTRY_VARIANT);
+    entries.push(["header", _("Amazon Cloud Player")]);
+    entries.push(["label", _("Preferred national variant")]);
+    for (var i = 0; i < COUNTRY_VARIANTS.length; i++)
+        entries.push(["option", COUNTRY_VARIANT, COUNTRY_VARIANTS[i][0], COUNTRY_VARIANTS[i][1]]);
+}
+
+
+WebApp._onInitAppRunner = function(emitter)
+{
+    Nuvola.core.connect("InitializationForm", this);
+    Nuvola.core.connect("PreferencesForm", this);
+}
+
+WebApp._onPreferencesForm = function(emitter, values, entries)
+{
+    this.appendPreferences(values, entries);
+}
+
+
+WebApp._onHomePageRequest = function(emitter, result)
+{
+    result.url = Nuvola.format(HOME_PAGE, Nuvola.config.get(COUNTRY_VARIANT));
 }
 
 WebApp.getMP3Player = function()

--- a/metadata.json
+++ b/metadata.json
@@ -7,5 +7,6 @@
     "version_minor": 0,
     "api_major": 3,
     "api_minor": 0,
-    "categories": "AudioVideo;Audio;"
+    "categories": "AudioVideo;Audio;",
+    "allowed_uri" : "^https?://www.amazon.[a-z.]+/gp/dmusic/cloudplayer/player#?.*$"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,5 @@
     "version_minor": 0,
     "api_major": 3,
     "api_minor": 0,
-    "categories": "AudioVideo;Audio;",
-    "home_url": "https://www.amazon.com/gp/dmusic/cloudplayer/player",
-    "allowed_uri" : "^https?://www.amazon.com/gp/dmusic/cloudplayer/player#?.*$"
+    "categories": "AudioVideo;Audio;"
 }


### PR DESCRIPTION
Amazon Cloud Player has multiple national variants with
different URL. Initialization form is used to let user
select its preferred national variant for the first time
and this option can be later changed in preferences
form.
- Author: Steffen Coenen steffen@steffen-coenen.de
- Reviewed by: Jiří Janoušek janousek.jiri@gmail.com
- Pull request: tiliado/nuvola-app-amazon-cloud-player#4
