### PR TITLE
Don't assume DOM hasn't been loaded yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,5 @@ Changelog
 
   * Added a complete icon set.
   * Added a license field to metadata.json.
+  * Script now doesn't assume that it is always executed before a basic structure of a web page is
+    loaded. This isn't guaranteed and it leads to an incompatibility with Nuvola Player 3.0.3.

--- a/integrate.js
+++ b/integrate.js
@@ -58,8 +58,11 @@ WebApp._onInitWebWorker = function(emitter)
     Nuvola.config.setDefault(COUNTRY_VARIANT, "");
     this.state = PlaybackState.UNKNOWN;
 
-    document.addEventListener("DOMContentLoaded", this._onPageReady.bind(this));
-    Nuvola.core.connect("InitializationForm", this);
+    var state = document.readyState;
+    if (state === "interactive" || state === "complete")
+        this._onPageReady();
+    else
+        document.addEventListener("DOMContentLoaded", this._onPageReady.bind(this));
 }
 
 // Page is ready for magic


### PR DESCRIPTION
This isn't guaranteed and it leads to an incompatibility with Nuvola
Player 3.0.3 which emits InitWebWorker signal when DOM document is ready
already.
- Author: Jiří Janoušek janousek.jiri@gmail.com
- Reviewed by: FIXME <FIXME>

---

When merging this branch, please follow [Guidelines for Merge Commits](https://tiliado.github.io/nuvolaplayer/development/apps/guidelines.html#merge-commits), especially:
- Don't merge directly in GitHub as it produces a crappy commit message.
- The title of the pull request becomes the merge commit title (the first line of the merge commit).
- The description of the pull request up to the first horizontal separator/line becomes the merge commit body (separated from the title by a blank line).
- Fill in the `Reviewed by` line and add the `Pull Request` line.
