### PR TITLE
Press PlayAll instead of Play after restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 -----------------
 
   * Add Canadian region support.
+  * Play action now will press "second" play button whenn button in header is disabled.
 
 5.9 - February 24th, 2019
 -------------------------

--- a/integrate.js
+++ b/integrate.js
@@ -233,7 +233,17 @@
   }
 
   WebApp._getPlayButton = function () {
-    return this._getButton('.playButton.playerIconPlay')
+    var elm = document.querySelector('.playButton.playerIconPlay')
+    if (elm && elm.classList.contains('disabled')) {
+      // Check if currently playing since there always is a disabled .playerIconPlay
+      if (this._getPauseButton()) {
+        return null
+      } else {
+        return this._getButton('.headerPlayAll') || this._getButton('.playAll')
+      }
+    } else {
+      return elm
+    }
   }
 
   WebApp._getPauseButton = function () {


### PR DESCRIPTION
since the play button is disabled when the site is loaded and hasn't played anything this session which means the hotkey/mpris play button dons't work when the App is started and has to be opened and needs a click on the "second" play button.